### PR TITLE
feat: allow overriding auth file path via config

### DIFF
--- a/codex-rs/chatgpt/src/apply_command.rs
+++ b/codex-rs/chatgpt/src/apply_command.rs
@@ -31,7 +31,7 @@ pub async fn run_apply_command(
         ConfigOverrides::default(),
     )?;
 
-    init_chatgpt_token_from_auth(&config.codex_home, &config.responses_originator_header).await?;
+    init_chatgpt_token_from_auth(&config.auth_file, &config.responses_originator_header).await?;
 
     let task_response = get_task(&config, apply_cli.task_id).await?;
     apply_diff_from_task(task_response, cwd).await

--- a/codex-rs/chatgpt/src/chatgpt_client.rs
+++ b/codex-rs/chatgpt/src/chatgpt_client.rs
@@ -13,7 +13,7 @@ pub(crate) async fn chatgpt_get_request<T: DeserializeOwned>(
     path: String,
 ) -> anyhow::Result<T> {
     let chatgpt_base_url = &config.chatgpt_base_url;
-    init_chatgpt_token_from_auth(&config.codex_home, &config.responses_originator_header).await?;
+    init_chatgpt_token_from_auth(&config.auth_file, &config.responses_originator_header).await?;
 
     // Make direct HTTP request to ChatGPT backend API with the token
     let client = create_client(&config.responses_originator_header);

--- a/codex-rs/chatgpt/src/chatgpt_token.rs
+++ b/codex-rs/chatgpt/src/chatgpt_token.rs
@@ -20,10 +20,10 @@ pub fn set_chatgpt_token_data(value: TokenData) {
 
 /// Initialize the ChatGPT token from auth.json file
 pub async fn init_chatgpt_token_from_auth(
-    codex_home: &Path,
+    auth_file: &Path,
     originator: &str,
 ) -> std::io::Result<()> {
-    let auth = CodexAuth::from_codex_home(codex_home, AuthMode::ChatGPT, originator)?;
+    let auth = CodexAuth::from_auth_file(auth_file, AuthMode::ChatGPT, originator)?;
     if let Some(auth) = auth {
         let token_data = auth.get_token_data().await?;
         set_chatgpt_token_data(token_data);

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -12,8 +12,13 @@ use codex_protocol::mcp_protocol::AuthMode;
 use std::env;
 use std::path::PathBuf;
 
-pub async fn login_with_chatgpt(codex_home: PathBuf, originator: String) -> std::io::Result<()> {
-    let opts = ServerOptions::new(codex_home, CLIENT_ID.to_string(), originator);
+pub async fn login_with_chatgpt(
+    codex_home: PathBuf,
+    auth_file: PathBuf,
+    originator: String,
+) -> std::io::Result<()> {
+    let mut opts = ServerOptions::new(codex_home, CLIENT_ID.to_string(), originator);
+    opts.auth_file = auth_file;
     let server = run_login_server(opts)?;
 
     eprintln!(
@@ -29,6 +34,7 @@ pub async fn run_login_with_chatgpt(cli_config_overrides: CliConfigOverrides) ->
 
     match login_with_chatgpt(
         config.codex_home,
+        config.auth_file,
         config.responses_originator_header.clone(),
     )
     .await
@@ -50,7 +56,7 @@ pub async fn run_login_with_api_key(
 ) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match login_with_api_key(&config.codex_home, &api_key) {
+    match login_with_api_key(&config.auth_file, &api_key) {
         Ok(_) => {
             eprintln!("Successfully logged in");
             std::process::exit(0);
@@ -65,8 +71,8 @@ pub async fn run_login_with_api_key(
 pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match CodexAuth::from_codex_home(
-        &config.codex_home,
+    match CodexAuth::from_auth_file(
+        &config.auth_file,
         config.preferred_auth_method,
         &config.responses_originator_header,
     ) {
@@ -108,7 +114,7 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
 pub async fn run_logout(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match logout(&config.codex_home) {
+    match logout(&config.auth_file) {
         Ok(true) => {
             eprintln!("Successfully logged out");
             std::process::exit(0);

--- a/codex-rs/cli/src/proto.rs
+++ b/codex-rs/cli/src/proto.rs
@@ -38,7 +38,7 @@ pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
     let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
     // Use conversation_manager API to start a conversation
     let conversation_manager = ConversationManager::new(AuthManager::shared(
-        config.codex_home.clone(),
+        config.auth_file.clone(),
         config.preferred_auth_method,
         config.responses_originator_header.clone(),
     ));

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -77,7 +77,22 @@ impl CodexAuth {
         preferred_auth_method: AuthMode,
         originator: &str,
     ) -> std::io::Result<Option<CodexAuth>> {
-        load_auth(codex_home, true, preferred_auth_method, originator)
+        load_auth(
+            &get_auth_file(codex_home),
+            true,
+            preferred_auth_method,
+            originator,
+        )
+    }
+
+    /// Loads auth information from a specific auth.json file or
+    /// the OPENAI_API_KEY environment variable.
+    pub fn from_auth_file(
+        auth_file: &Path,
+        preferred_auth_method: AuthMode,
+        originator: &str,
+    ) -> std::io::Result<Option<CodexAuth>> {
+        load_auth(auth_file, true, preferred_auth_method, originator)
     }
 
     pub async fn get_token_data(&self) -> Result<TokenData, std::io::Error> {
@@ -209,9 +224,8 @@ pub fn get_auth_file(codex_home: &Path) -> PathBuf {
 
 /// Delete the auth.json file inside `codex_home` if it exists. Returns `Ok(true)`
 /// if a file was removed, `Ok(false)` if no auth file was present.
-pub fn logout(codex_home: &Path) -> std::io::Result<bool> {
-    let auth_file = get_auth_file(codex_home);
-    match std::fs::remove_file(&auth_file) {
+pub fn logout(auth_file: &Path) -> std::io::Result<bool> {
+    match std::fs::remove_file(auth_file) {
         Ok(_) => Ok(true),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(err) => Err(err),
@@ -219,17 +233,20 @@ pub fn logout(codex_home: &Path) -> std::io::Result<bool> {
 }
 
 /// Writes an `auth.json` that contains only the API key. Intended for CLI use.
-pub fn login_with_api_key(codex_home: &Path, api_key: &str) -> std::io::Result<()> {
+pub fn login_with_api_key(auth_file: &Path, api_key: &str) -> std::io::Result<()> {
     let auth_dot_json = AuthDotJson {
         openai_api_key: Some(api_key.to_string()),
         tokens: None,
         last_refresh: None,
     };
-    write_auth_json(&get_auth_file(codex_home), &auth_dot_json)
+    if let Some(parent) = auth_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_auth_json(auth_file, &auth_dot_json)
 }
 
 fn load_auth(
-    codex_home: &Path,
+    auth_file: &Path,
     include_env_var: bool,
     preferred_auth_method: AuthMode,
     originator: &str,
@@ -237,9 +254,8 @@ fn load_auth(
     // First, check to see if there is a valid auth.json file. If not, we fall
     // back to AuthMode::ApiKey using the OPENAI_API_KEY environment variable
     // (if it is set).
-    let auth_file = get_auth_file(codex_home);
     let client = crate::default_client::create_client(originator);
-    let auth_dot_json = match try_read_auth_json(&auth_file) {
+    let auth_dot_json = match try_read_auth_json(auth_file) {
         Ok(auth) => auth,
         // If auth.json does not exist, try to read the OPENAI_API_KEY from the
         // environment variable.
@@ -291,7 +307,7 @@ fn load_auth(
     Ok(Some(CodexAuth {
         api_key: None,
         mode: AuthMode::ChatGPT,
-        auth_file,
+        auth_file: auth_file.to_path_buf(),
         auth_dot_json: Arc::new(Mutex::new(Some(AuthDotJson {
             openai_api_key: None,
             tokens,
@@ -473,7 +489,7 @@ mod tests {
             auth_dot_json,
             auth_file: _,
             ..
-        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        } = super::load_auth(&get_auth_file(codex_home.path()), false, AuthMode::ChatGPT, "codex_cli_rs")
             .unwrap()
             .unwrap();
         assert_eq!(None, api_key);
@@ -525,7 +541,7 @@ mod tests {
             auth_dot_json,
             auth_file: _,
             ..
-        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        } = super::load_auth(&get_auth_file(codex_home.path()), false, AuthMode::ChatGPT, "codex_cli_rs")
             .unwrap()
             .unwrap();
         assert_eq!(None, api_key);
@@ -576,7 +592,7 @@ mod tests {
             auth_dot_json,
             auth_file: _,
             ..
-        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        } = super::load_auth(&get_auth_file(codex_home.path()), false, AuthMode::ChatGPT, "codex_cli_rs")
             .unwrap()
             .unwrap();
         assert_eq!(Some("sk-test-key".to_string()), api_key);
@@ -596,7 +612,7 @@ mod tests {
         )
         .unwrap();
 
-        let auth = super::load_auth(dir.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        let auth = super::load_auth(&get_auth_file(dir.path()), false, AuthMode::ChatGPT, "codex_cli_rs")
             .unwrap()
             .unwrap();
         assert_eq!(auth.mode, AuthMode::ApiKey);
@@ -615,7 +631,7 @@ mod tests {
         };
         write_auth_json(&get_auth_file(dir.path()), &auth_dot_json)?;
         assert!(dir.path().join("auth.json").exists());
-        let removed = logout(dir.path())?;
+        let removed = logout(&get_auth_file(dir.path()))?;
         assert!(removed);
         assert!(!dir.path().join("auth.json").exists());
         Ok(())
@@ -679,7 +695,7 @@ mod tests {
 /// different parts of the program seeing inconsistent auth data mid‑run.
 #[derive(Debug)]
 pub struct AuthManager {
-    codex_home: PathBuf,
+    auth_file: PathBuf,
     originator: String,
     inner: RwLock<CachedAuth>,
 }
@@ -689,12 +705,12 @@ impl AuthManager {
     /// preferred auth method. Errors loading auth are swallowed; `auth()` will
     /// simply return `None` in that case so callers can treat it as an
     /// unauthenticated state.
-    pub fn new(codex_home: PathBuf, preferred_auth_mode: AuthMode, originator: String) -> Self {
-        let auth = CodexAuth::from_codex_home(&codex_home, preferred_auth_mode, &originator)
+    pub fn new(auth_file: PathBuf, preferred_auth_mode: AuthMode, originator: String) -> Self {
+        let auth = CodexAuth::from_auth_file(&auth_file, preferred_auth_mode, &originator)
             .ok()
             .flatten();
         Self {
-            codex_home,
+            auth_file,
             originator,
             inner: RwLock::new(CachedAuth {
                 preferred_auth_mode,
@@ -711,7 +727,7 @@ impl AuthManager {
             auth: Some(auth),
         };
         Arc::new(Self {
-            codex_home: PathBuf::new(),
+            auth_file: PathBuf::new(),
             originator: "codex_cli_rs".to_string(),
             inner: RwLock::new(cached),
         })
@@ -734,7 +750,7 @@ impl AuthManager {
     /// whether the auth value changed.
     pub fn reload(&self) -> bool {
         let preferred = self.preferred_auth_method();
-        let new_auth = CodexAuth::from_codex_home(&self.codex_home, preferred, &self.originator)
+        let new_auth = CodexAuth::from_auth_file(&self.auth_file, preferred, &self.originator)
             .ok()
             .flatten();
         if let Ok(mut guard) = self.inner.write() {
@@ -756,11 +772,11 @@ impl AuthManager {
 
     /// Convenience constructor returning an `Arc` wrapper.
     pub fn shared(
-        codex_home: PathBuf,
+        auth_file: PathBuf,
         preferred_auth_mode: AuthMode,
         originator: String,
     ) -> Arc<Self> {
-        Arc::new(Self::new(codex_home, preferred_auth_mode, originator))
+        Arc::new(Self::new(auth_file, preferred_auth_mode, originator))
     }
 
     /// Attempt to refresh the current auth token (if any). On success, reload
@@ -785,7 +801,7 @@ impl AuthManager {
     /// reloads the in‑memory auth cache so callers immediately observe the
     /// unauthenticated state.
     pub fn logout(&self) -> std::io::Result<bool> {
-        let removed = super::auth::logout(&self.codex_home)?;
+        let removed = super::auth::logout(&self.auth_file)?;
         // Always reload to clear any cached auth (even if file absent).
         self.reload();
         Ok(removed)

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -124,6 +124,10 @@ pub struct Config {
     /// overridden by the `CODEX_HOME` environment variable).
     pub codex_home: PathBuf,
 
+    /// Location of the auth.json file. Defaults to `codex_home/auth.json` but can
+    /// be overridden via `config.toml`.
+    pub auth_file: PathBuf,
+
     /// Settings that govern if and what will be written to `~/.codex/history.jsonl`.
     pub history: History,
 
@@ -429,6 +433,9 @@ pub struct ConfigToml {
 
     /// Maximum number of bytes to include from an AGENTS.md project doc file.
     pub project_doc_max_bytes: Option<usize>,
+
+    /// Path to an alternate auth.json file. Defaults to `~/.codex/auth.json`.
+    pub auth_file: Option<PathBuf>,
 
     /// Profile to use from the `profiles` map.
     pub profile: Option<String>,
@@ -777,6 +784,11 @@ impl Config {
             .responses_originator_header_internal_override
             .unwrap_or(DEFAULT_RESPONSES_ORIGINATOR_HEADER.to_owned());
 
+        let auth_file = cfg
+            .auth_file
+            .clone()
+            .unwrap_or_else(|| codex_home.join("auth.json"));
+
         let config = Self {
             model,
             model_family,
@@ -798,6 +810,7 @@ impl Config {
             model_providers,
             project_doc_max_bytes: cfg.project_doc_max_bytes.unwrap_or(PROJECT_DOC_MAX_BYTES),
             codex_home,
+            auth_file,
             history,
             file_opener: cfg.file_opener.unwrap_or(UriBasedFileOpener::VsCode),
             tui: cfg.tui.unwrap_or_default(),
@@ -1188,6 +1201,7 @@ model_verbosity = "high"
                 model_providers: fixture.model_provider_map.clone(),
                 project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
                 codex_home: fixture.codex_home(),
+                auth_file: fixture.codex_home().join("auth.json"),
                 history: History::default(),
                 file_opener: UriBasedFileOpener::VsCode,
                 tui: Tui::default(),
@@ -1245,6 +1259,7 @@ model_verbosity = "high"
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             codex_home: fixture.codex_home(),
+            auth_file: fixture.codex_home().join("auth.json"),
             history: History::default(),
             file_opener: UriBasedFileOpener::VsCode,
             tui: Tui::default(),
@@ -1317,6 +1332,7 @@ model_verbosity = "high"
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             codex_home: fixture.codex_home(),
+            auth_file: fixture.codex_home().join("auth.json"),
             history: History::default(),
             file_opener: UriBasedFileOpener::VsCode,
             tui: Tui::default(),
@@ -1375,6 +1391,7 @@ model_verbosity = "high"
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             codex_home: fixture.codex_home(),
+            auth_file: fixture.codex_home().join("auth.json"),
             history: History::default(),
             file_opener: UriBasedFileOpener::VsCode,
             tui: Tui::default(),

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -188,7 +188,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     }
 
     let conversation_manager = ConversationManager::new(AuthManager::shared(
-        config.codex_home.clone(),
+        config.auth_file.clone(),
         config.preferred_auth_method,
         config.responses_originator_header.clone(),
     ));

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -36,10 +36,12 @@ pub struct ServerOptions {
     pub open_browser: bool,
     pub force_state: Option<String>,
     pub originator: String,
+    pub auth_file: PathBuf,
 }
 
 impl ServerOptions {
     pub fn new(codex_home: PathBuf, client_id: String, originator: String) -> Self {
+        let auth_file = get_auth_file(&codex_home);
         Self {
             codex_home,
             client_id: client_id.to_string(),
@@ -48,6 +50,7 @@ impl ServerOptions {
             open_browser: true,
             force_state: None,
             originator,
+            auth_file,
         }
     }
 }
@@ -243,7 +246,7 @@ async fn process_request(
                         .await
                         .ok();
                     if let Err(err) = persist_tokens_async(
-                        &opts.codex_home,
+                        &opts.auth_file,
                         api_key.clone(),
                         tokens.id_token.clone(),
                         Some(tokens.access_token.clone()),
@@ -452,16 +455,15 @@ async fn exchange_code_for_tokens(
 }
 
 async fn persist_tokens_async(
-    codex_home: &Path,
+    auth_file: &Path,
     api_key: Option<String>,
     id_token: String,
     access_token: Option<String>,
     refresh_token: Option<String>,
 ) -> io::Result<()> {
     // Reuse existing synchronous logic but run it off the async runtime.
-    let codex_home = codex_home.to_path_buf();
+    let auth_file = auth_file.to_path_buf();
     tokio::task::spawn_blocking(move || {
-        let auth_file = get_auth_file(&codex_home);
         if let Some(parent) = auth_file.parent()
             && !parent.exists()
         {

--- a/codex-rs/login/tests/suite/login_server_e2e.rs
+++ b/codex-rs/login/tests/suite/login_server_e2e.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use base64::Engine;
 use codex_login::ServerOptions;
 use codex_login::run_login_server;
+use codex_login::get_auth_file;
 use tempfile::tempdir;
 
 // See spawn.rs for details
@@ -97,6 +98,7 @@ async fn end_to_end_login_flow_persists_auth_json() {
 
     let opts = ServerOptions {
         codex_home: server_home,
+        auth_file: get_auth_file(&codex_home),
         client_id: codex_login::CLIENT_ID.to_string(),
         issuer,
         port: 0,
@@ -156,6 +158,7 @@ async fn creates_missing_codex_home_dir() {
     let server_home = codex_home.clone();
     let opts = ServerOptions {
         codex_home: server_home,
+        auth_file: get_auth_file(&codex_home),
         client_id: codex_login::CLIENT_ID.to_string(),
         issuer,
         port: 0,
@@ -197,6 +200,7 @@ async fn cancels_previous_login_server_when_port_is_in_use() {
 
     let first_opts = ServerOptions {
         codex_home: first_codex_home,
+        auth_file: get_auth_file(first_tmp.path()),
         client_id: codex_login::CLIENT_ID.to_string(),
         issuer: issuer.clone(),
         port: 0,
@@ -216,6 +220,7 @@ async fn cancels_previous_login_server_when_port_is_in_use() {
 
     let second_opts = ServerOptions {
         codex_home: second_codex_home,
+        auth_file: get_auth_file(second_tmp.path()),
         client_id: codex_login::CLIENT_ID.to_string(),
         issuer,
         port: login_port,

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -187,14 +187,13 @@ impl CodexMessageProcessor {
     async fn login_chatgpt(&mut self, request_id: RequestId) {
         let config = self.config.as_ref();
 
-        let opts = LoginServerOptions {
-            open_browser: false,
-            ..LoginServerOptions::new(
-                config.codex_home.clone(),
-                CLIENT_ID.to_string(),
-                config.responses_originator_header.clone(),
-            )
-        };
+        let mut opts = LoginServerOptions::new(
+            config.codex_home.clone(),
+            CLIENT_ID.to_string(),
+            config.responses_originator_header.clone(),
+        );
+        opts.open_browser = false;
+        opts.auth_file = config.auth_file.clone();
 
         enum LoginChatGptReply {
             Response(LoginChatGptResponse),

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -55,7 +55,7 @@ impl MessageProcessor {
     ) -> Self {
         let outgoing = Arc::new(outgoing);
         let auth_manager = AuthManager::shared(
-            config.codex_home.clone(),
+            config.auth_file.clone(),
             config.preferred_auth_method,
             config.responses_originator_header.clone(),
         );

--- a/codex-rs/mcp-server/tests/suite/archive_conversation.rs
+++ b/codex-rs/mcp-server/tests/suite/archive_conversation.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use codex_core::ARCHIVED_SESSIONS_SUBDIR;
+use codex_protocol::mcp_protocol::ArchiveConversationParams;
+use codex_protocol::mcp_protocol::ArchiveConversationResponse;
+use codex_protocol::mcp_protocol::NewConversationParams;
+use codex_protocol::mcp_protocol::NewConversationResponse;
+use mcp_test_support::McpProcess;
+use mcp_test_support::to_response;
+use mcp_types::JSONRPCResponse;
+use mcp_types::RequestId;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_conversation_moves_rollout_into_archived_directory() {
+    let codex_home = TempDir::new().expect("create temp dir");
+    create_config_toml(codex_home.path()).expect("write config.toml");
+
+    let mut mcp = McpProcess::new(codex_home.path())
+        .await
+        .expect("spawn mcp process");
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize())
+        .await
+        .expect("initialize timeout")
+        .expect("initialize request");
+
+    let new_request_id = mcp
+        .send_new_conversation_request(NewConversationParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send newConversation");
+    let new_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(new_request_id)),
+    )
+    .await
+    .expect("newConversation timeout")
+    .expect("newConversation response");
+
+    let NewConversationResponse {
+        conversation_id,
+        rollout_path,
+        ..
+    } = to_response::<NewConversationResponse>(new_response)
+        .expect("deserialize newConversation response");
+
+    assert!(
+        rollout_path.exists(),
+        "expected rollout path {} to exist",
+        rollout_path.display()
+    );
+
+    let archive_request_id = mcp
+        .send_archive_conversation_request(ArchiveConversationParams {
+            conversation_id,
+            rollout_path: rollout_path.clone(),
+        })
+        .await
+        .expect("send archiveConversation");
+    let archive_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(archive_request_id)),
+    )
+    .await
+    .expect("archiveConversation timeout")
+    .expect("archiveConversation response");
+
+    let _: ArchiveConversationResponse =
+        to_response::<ArchiveConversationResponse>(archive_response)
+            .expect("deserialize archiveConversation response");
+
+    let archived_directory = codex_home.path().join(ARCHIVED_SESSIONS_SUBDIR);
+    let archived_rollout_path =
+        archived_directory.join(rollout_path.file_name().unwrap_or_else(|| {
+            panic!("rollout path {} missing file name", rollout_path.display())
+        }));
+
+    assert!(
+        !rollout_path.exists(),
+        "expected rollout path {} to be moved",
+        rollout_path.display()
+    );
+    assert!(
+        archived_rollout_path.exists(),
+        "expected archived rollout path {} to exist",
+        archived_rollout_path.display()
+    );
+}
+
+fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
+    let config_toml = codex_home.join("config.toml");
+    std::fs::write(config_toml, config_contents())
+}
+
+fn config_contents() -> &'static str {
+    r#"model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "read-only"
+"#
+}

--- a/codex-rs/mcp-server/tests/suite/auth.rs
+++ b/codex-rs/mcp-server/tests/suite/auth.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use codex_core::auth::get_auth_file;
 use codex_core::auth::login_with_api_key;
 use codex_protocol::mcp_protocol::AuthMode;
 use codex_protocol::mcp_protocol::GetAuthStatusParams;
@@ -73,7 +74,7 @@ async fn get_auth_status_no_auth() {
 async fn get_auth_status_with_api_key() {
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml(codex_home.path()).expect("write config.toml");
-    login_with_api_key(codex_home.path(), "sk-test-key").expect("seed api key");
+    login_with_api_key(&get_auth_file(codex_home.path()), "sk-test-key").expect("seed api key");
 
     let mut mcp = McpProcess::new(codex_home.path())
         .await
@@ -108,7 +109,7 @@ async fn get_auth_status_with_api_key() {
 async fn get_auth_status_with_api_key_no_include_token() {
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml(codex_home.path()).expect("write config.toml");
-    login_with_api_key(codex_home.path(), "sk-test-key").expect("seed api key");
+    login_with_api_key(&get_auth_file(codex_home.path()), "sk-test-key").expect("seed api key");
 
     let mut mcp = McpProcess::new(codex_home.path())
         .await

--- a/codex-rs/mcp-server/tests/suite/login.rs
+++ b/codex-rs/mcp-server/tests/suite/login.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use codex_core::auth::get_auth_file;
 use codex_core::auth::login_with_api_key;
 use codex_protocol::mcp_protocol::CancelLoginChatGptParams;
 use codex_protocol::mcp_protocol::CancelLoginChatGptResponse;
@@ -43,7 +44,7 @@ stream_max_retries = 0
 async fn logout_chatgpt_removes_auth() {
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml(codex_home.path()).expect("write config.toml");
-    login_with_api_key(codex_home.path(), "sk-test-key").expect("seed api key");
+    login_with_api_key(&get_auth_file(codex_home.path()), "sk-test-key").expect("seed api key");
     assert!(codex_home.path().join("auth.json").exists());
 
     let mut mcp = McpProcess::new(codex_home.path())

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -840,7 +840,7 @@ impl ChatWidget {
                 self.app_event_tx.send(AppEvent::ExitRequest);
             }
             SlashCommand::Logout => {
-                if let Err(e) = codex_core::auth::logout(&self.config.codex_home) {
+                if let Err(e) = codex_core::auth::logout(&self.config.auth_file) {
                     tracing::error!("failed to logout: {e}");
                 }
                 self.app_event_tx.send(AppEvent::ExitRequest);

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -14,7 +14,6 @@ use base64::Engine;
 use codex_ansi_escape::ansi_escape_line;
 use codex_common::create_config_summary_entries;
 use codex_common::elapsed::format_duration;
-use codex_core::auth::get_auth_file;
 use codex_core::auth::try_read_auth_json;
 use codex_core::config::Config;
 use codex_core::config_types::ReasoningSummaryFormat;
@@ -906,8 +905,8 @@ pub(crate) fn new_status_output(
     lines.push("".into());
 
     // 👤 Account (only if ChatGPT tokens exist), shown under the first block
-    let auth_file = get_auth_file(&config.codex_home);
-    if let Ok(auth) = try_read_auth_json(&auth_file)
+    let auth_file = &config.auth_file;
+    if let Ok(auth) = try_read_auth_json(auth_file)
         && let Some(tokens) = auth.tokens.clone()
     {
         lines.push(vec![padded_emoji("👤").into(), "Account".bold()].into());

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -313,7 +313,7 @@ async fn run_ratatui_app(
     } = cli;
 
     let auth_manager = AuthManager::shared(
-        config.codex_home.clone(),
+        config.auth_file.clone(),
         config.preferred_auth_method,
         config.responses_originator_header.clone(),
     );
@@ -399,9 +399,9 @@ fn get_login_status(config: &Config) -> LoginStatus {
     if config.model_provider.requires_openai_auth {
         // Reading the OpenAI API key is an async operation because it may need
         // to refresh the token. Block on it.
-        let codex_home = config.codex_home.clone();
-        match CodexAuth::from_codex_home(
-            &codex_home,
+        let auth_file = config.auth_file.clone();
+        match CodexAuth::from_auth_file(
+            &auth_file,
             config.preferred_auth_method,
             &config.responses_originator_header,
         ) {

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -111,6 +111,7 @@ pub(crate) struct AuthModeWidget {
     pub error: Option<String>,
     pub sign_in_state: Arc<RwLock<SignInState>>,
     pub codex_home: PathBuf,
+    pub auth_file: PathBuf,
     pub login_status: LoginStatus,
     pub preferred_auth_method: AuthMode,
     pub auth_manager: Arc<AuthManager>,
@@ -316,11 +317,12 @@ impl AuthModeWidget {
         }
 
         self.error = None;
-        let opts = ServerOptions::new(
+        let mut opts = ServerOptions::new(
             self.codex_home.clone(),
             CLIENT_ID.to_string(),
             self.config.responses_originator_header.clone(),
         );
+        opts.auth_file = self.auth_file.clone();
         match run_login_server(opts) {
             Ok(child) => {
                 let sign_in_state = self.sign_in_state.clone();

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -72,6 +72,7 @@ impl OnboardingScreen {
         let preferred_auth_method = config.preferred_auth_method;
         let cwd = config.cwd.clone();
         let codex_home = config.codex_home.clone();
+        let auth_file = config.auth_file.clone();
         let mut steps: Vec<Step> = vec![Step::Welcome(WelcomeWidget {
             is_logged_in: !matches!(login_status, LoginStatus::NotAuthenticated),
         })];
@@ -82,6 +83,7 @@ impl OnboardingScreen {
                 error: None,
                 sign_in_state: Arc::new(RwLock::new(SignInState::PickMode)),
                 codex_home: codex_home.clone(),
+                auth_file,
                 login_status,
                 auth_manager,
                 preferred_auth_method,

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -78,6 +78,19 @@ or try this one-liner:
 ssh user@remote 'mkdir -p ~/.codex && cat > ~/.codex/auth.json' < ~/.codex/auth.json
 ```
 
+### Overriding the auth file location
+
+By default Codex reads credentials from `$CODEX_HOME/auth.json`. This path can
+be overridden in `config.toml`:
+
+```toml
+# ~/.codex/config.toml
+auth_file = "/path/to/custom/auth.json"
+```
+
+Project-specific `config.toml` files can set their own `auth_file` to use
+different credentials per workspace.
+
 ### Connecting through VPS or remote
 
 If you run Codex on a remote machine (VPS/server) without a local browser, the login helper starts a server on `localhost:1455` on the remote host. To complete login in your local browser, forward that port to your machine before starting the login flow:

--- a/docs/config.md
+++ b/docs/config.md
@@ -552,6 +552,16 @@ This is analogous to `model_context_window`, but for the maximum number of outpu
 
 Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
 
+## auth_file
+
+Override the location of the `auth.json` file used for authentication. By
+default this file lives at `$CODEX_HOME/auth.json`, but specifying `auth_file`
+allows per-project credentials.
+
+```toml
+auth_file = "/path/to/auth.json"
+```
+
 ## tui
 
 Options that are specific to the TUI.
@@ -593,6 +603,7 @@ Options that are specific to the TUI.
 | `model_providers.<id>.stream_max_retries` | number | SSE stream retry count (default: 5). |
 | `model_providers.<id>.stream_idle_timeout_ms` | number | SSE idle timeout (ms) (default: 300000). |
 | `project_doc_max_bytes` | number | Max bytes to read from `AGENTS.md`. |
+| `auth_file` | string (path) | Override path to `auth.json`. |
 | `profile` | string | Active profile name. |
 | `profiles.<name>.*` | various | Profile‑scoped overrides of the same keys. |
 | `history.persistence` | `save-all` \| `none` | History file persistence (default: `save-all`). |


### PR DESCRIPTION
## Summary
- allow configuring auth.json path with new `auth_file` setting
- wire auth file into login flows and auth manager
- document auth_file in config and authentication guides

## Testing
- `cargo test -p codex-core` *(fails: integration tests hang)*
- `cargo test -p codex-login`
- `cargo test -p codex-cli`
- `cargo test -p codex-exec` *(fails: suite::sandbox::python_multiprocessing_lock_works_under_sandbox)*
- `cargo test -p codex-mcp-server`
- `cargo test -p codex-tui`
- `cargo test -p codex-chatgpt`


------
https://chatgpt.com/codex/tasks/task_e_68bfc7d22f5483299e0fcfe7476a0374